### PR TITLE
Allow all orgs to be endorsers

### DIFF
--- a/src/auction/auction-simple/chaincode-go/smart-contract/auction.go
+++ b/src/auction/auction-simple/chaincode-go/smart-contract/auction.go
@@ -28,6 +28,7 @@ type SmartContract struct {
 
 // Auction data
 type Auction struct {
+	AuctionID   string    `json:"AuctionID"`
 	Type        string    `json:"objectType"`
 	ItemSold    string    `json:"item"`
 	Seller      string    `json:"seller"`
@@ -81,6 +82,7 @@ func (s *SmartContract) CreateAuction(ctx contractapi.TransactionContextInterfac
 
 	// Create auction
 	auction := Auction{
+		AuctionID:   auctionID,
 		Type:        "auction",
 		ItemSold:    itemsold,
 		Price:       0,
@@ -106,10 +108,10 @@ func (s *SmartContract) CreateAuction(ctx contractapi.TransactionContextInterfac
 	}
 
 	// set the seller of the auction as an endorser
-	// err = setAssetStateBasedEndorsement(ctx, auctionID, clientOrgID)
+	err = setAssetStateBasedEndorsement(ctx, auctionID, clientOrgID)
 
 	// This allows any organization to endorse transactions
-	err = ctx.GetStub().SetStateValidationParameter(auctionID, nil)
+	// err = ctx.GetStub().SetStateValidationParameter(auctionID, nil)
 	if err != nil {
 		return fmt.Errorf("failed setting state based endorsement for new organization: %v", err)
 	}
@@ -193,9 +195,9 @@ func (s *SmartContract) SubmitBid(ctx contractapi.TransactionContextInterface, a
 	// var timestamps []string
 	var timestamps string = body
 	// err = json.Unmarshal(body, &timestamps)
-	if err != nil {
-		return fmt.Errorf("failed to parse API response: %v with body: %v", err, string(body))
-	}
+	// if err != nil {
+	// 	return fmt.Errorf("failed to parse API response: %v with body: %v", err, string(body))
+	// }
 
 	encodedValue := encodeValue(txID)
 	shuffledTimestamps := shuffleTimestamps([]string{timestamps}, encodedValue)

--- a/src/auction/auction-simple/chaincode-go/smart-contract/auctionQueries.go
+++ b/src/auction/auction-simple/chaincode-go/smart-contract/auctionQueries.go
@@ -150,7 +150,12 @@ func (s *SmartContract) GetAllAuctionsBySeller(ctx contractapi.TransactionContex
 			continue
 		}
 
-		if auction.Seller == sellerID {
+		auctionSeller, err := s.ParseClientID(auction.Seller)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse auction seller: %v", err)
+		}
+
+		if auctionSeller == sellerID {
 			results = append(results, &auction)
 		}
 	}

--- a/src/auction/auction-simple/chaincode-go/smart-contract/utils.go
+++ b/src/auction/auction-simple/chaincode-go/smart-contract/utils.go
@@ -17,28 +17,29 @@ import (
 )
 
 func (s *SmartContract) GetSubmittingClientIdentity(ctx contractapi.TransactionContextInterface) (string, error) {
-	// reference: https://github.com/hyperledger/fabric-chaincode-go/blob/main/pkg/cid/interfaces.go
 	b64ID, err := ctx.GetClientIdentity().GetID()
 	if err != nil {
-		return "", fmt.Errorf("Failed to read clientID: %v", err)
+		return "", fmt.Errorf("failed to read clientID: %v", err)
 	}
 	decodeID, err := base64.StdEncoding.DecodeString(b64ID)
 	if err != nil {
 		return "", fmt.Errorf("failed to base64 decode clientID: %v", err)
 	}
+	return string(decodeID), nil
+}
 
-	// Extract CN from the X.509 subject
-	// "x509::CN=seller_01,OU=client::CN=ca.org1.example.com,O=org1.example.com,L=Durham,ST=North Carolina,C=US"
-	idStr := string(decodeID)
-	if strings.HasPrefix(idStr, "x509::") {
-		// Split by CN= and get the first part
-		parts := strings.Split(idStr, "CN=")
-		if len(parts) > 1 {
-			// Get the CN value and split by comma to get just the CN
-			cnParts := strings.Split(parts[1], ",")
-			return cnParts[0], nil
-		}
-	}
+func (s *SmartContract) ParseClientID(idStr string) (string, error) {
+	// reference: https://github.com/hyperledger/fabric-chaincode-go/blob/main/pkg/cid/interfaces.go
+    // Extract CN from the X.509 subject
+    if strings.HasPrefix(idStr, "x509::") {
+        // Split by CN= and get the first part
+        parts := strings.Split(idStr, "CN=")
+        if len(parts) > 1 {
+            // Get the CN value and split by comma to get just the CN
+            cnParts := strings.Split(parts[1], ",")
+            return cnParts[0], nil
+        }
+    }
 
 	return idStr, nil
 }


### PR DESCRIPTION
## What

The `GetSubmittingClientIdentity` method now returns the userId, which is extracted from the `GetID` function of the `GetClientIdentity` interface. The GetID function returns a unique ID for the invoking identity within the MSP, and we only provide the CN (Common Name) value of that ID.

In the contract, we have changed the endorsement policy in the `CreateAuction` function to allow all Orgs to be endorsers. (Consistent with our endorsement policy in `fast-start.sh`)